### PR TITLE
Add hackernews datasource

### DIFF
--- a/configurations/configuration.default.json
+++ b/configurations/configuration.default.json
@@ -6,9 +6,10 @@
         "embedding": {
             "datasources": [
                 {
-                    "name": "pdf",
-                    "export_limit": 10,
-                    "base_path": "data/bavarian_beer"
+                    "name": "hackernews",
+                    "host": "hacker-news.firebaseio.com",
+                    "protocol": "https",
+                    "export_limit": 500
                 }
             ],
             "embedding_model": {
@@ -23,7 +24,7 @@
             },
             "vector_store": {
                 "name": "qdrant",
-                "collection_name": "collection-default",
+                "collection_name": "collection-default-hackernews",
                 "host": "qdrant",
                 "protocol": "http",
                 "ports": {

--- a/src/augmentation/utils.py
+++ b/src/augmentation/utils.py
@@ -15,7 +15,7 @@ class ConversationUtils:
         REFERENCES_TEMPLATE: Template string for formatting references section.
     """
 
-    WELCOME_TEMPLATE = "Welcome to our Bavarian Beer Chat! 🍻 We're here to guide you through the rich tapestry of Bavarian beer culture. Whether you're curious about traditional brews, local beer festivals, or the history behind Bavaria's renowned beer purity law, you've come to the right place. Type your question below, and let's embark on this flavorful journey together. Prost!"
+    WELCOME_TEMPLATE = "Welcome"
     REFERENCES_TEMPLATE = "\n\n**References**:\n" "{references}\n"
 
     @staticmethod

--- a/src/common/bootstrap/configuration/pipeline/embedding/datasources/datasources_binder.py
+++ b/src/common/bootstrap/configuration/pipeline/embedding/datasources/datasources_binder.py
@@ -11,6 +11,7 @@ from common.bootstrap.configuration.pipeline.embedding.datasources.datasources_b
 from common.bootstrap.configuration.pipeline.embedding.datasources.datasources_configuration import (
     ConfluenceDatasourceConfiguration,
     DatasourceName,
+    HackernewsDatasourceConfiguration,
     NotionDatasourceConfiguration,
     PdfDatasourceConfiguration,
 )
@@ -25,6 +26,14 @@ from embedding.datasources.confluence.cleaner import ConfluenceCleaner
 from embedding.datasources.confluence.manager import ConfluenceDatasourceManager
 from embedding.datasources.confluence.reader import ConfluenceReader
 from embedding.datasources.confluence.splitter import ConfluenceSplitter
+from embedding.datasources.hackernews.builders import (
+    HackernewsCleanerBuilder,
+    HackernewsDatasourceManagerBuilder,
+    HackernewsReaderBuilder,
+)
+from embedding.datasources.hackernews.cleaner import HackernewsCleaner
+from embedding.datasources.hackernews.manager import HackernewsDatasourceManager
+from embedding.datasources.hackernews.reader import HackernewsReader
 from embedding.datasources.notion.builders import (
     NotionCleanerBuilder,
     NotionClientBuilder,
@@ -228,6 +237,52 @@ class PdfDatasourcesBinder(BaseBinder):
         )
 
 
+class HackernewsBinder(BaseBinder):
+    """Binder for the Hacker News datasources components."""
+
+    def bind(self) -> Type:
+        """Bind the Hacker News datasources components.
+
+        Returns:
+            Type: The Hacker News datasource manager."""
+        self._bind_hackernews_configuration()
+        self._bind_reader()
+        self._bind_cleaner()
+        self._bind_manager()
+        return HackernewsDatasourceManager
+
+    def _bind_hackernews_configuration(self) -> None:
+        """Bind the Hacker News datasource configuration."""
+        hackernews_configuration = [
+            configuration
+            for configuration in self.configuration.pipeline.embedding.datasources
+            if isinstance(configuration, HackernewsDatasourceConfiguration)
+        ][0]
+        self.binder.bind(
+            HackernewsDatasourceConfiguration,
+            to=hackernews_configuration,
+            scope=singleton,
+        )
+
+    def _bind_reader(self) -> None:
+        """Bind the Hacker News reader."""
+        self.binder.bind(
+            HackernewsReader,
+            to=HackernewsReaderBuilder.build,
+        )
+
+    def _bind_cleaner(self) -> None:
+        """Bind the Hacker News cleaner."""
+        self.binder.bind(HackernewsCleaner, to=HackernewsCleanerBuilder.build)
+
+    def _bind_manager(self) -> None:
+        """Bind the Hacker News datasource manager."""
+        self.binder.bind(
+            HackernewsDatasourceManager,
+            to=HackernewsDatasourceManagerBuilder.build,
+        )
+
+
 class DatasourcesBinder(BaseBinder):
     """Binder for the datasources components.
 
@@ -237,6 +292,7 @@ class DatasourcesBinder(BaseBinder):
         DatasourceName.CONFLUENCE: ConfluenceBinder,
         DatasourceName.NOTION: NotionDatasourceBinder,
         DatasourceName.PDF: PdfDatasourcesBinder,
+        DatasourceName.HACKERNEWS: HackernewsBinder,
     }
 
     def bind(self) -> None:

--- a/src/common/bootstrap/configuration/pipeline/embedding/datasources/datasources_configuration.py
+++ b/src/common/bootstrap/configuration/pipeline/embedding/datasources/datasources_configuration.py
@@ -14,6 +14,7 @@ class DatasourceName(str, Enum):
     NOTION = "notion"
     CONFLUENCE = "confluence"
     PDF = "pdf"
+    HACKERNEWS = "hackernews"
 
 
 # Secrets
@@ -113,8 +114,27 @@ class PdfDatasourceConfiguration(DatasourceConfiguration):
     )
 
 
+class HackernewsDatasourceConfiguration(DatasourceConfiguration):
+    host: str = Field(
+        "hacker-news.firebaseio.com", description="Host of hackernews API."
+    )
+
+    protocol: Union[Literal["http"], Literal["https"]] = Field(
+        "https", description="The protocol for hackernews API."
+    )
+
+    name: Literal[DatasourceName.HACKERNEWS] = Field(
+        ..., description="The name of the data source."
+    )
+
+    @property
+    def base_url(self) -> str:
+        return f"{self.protocol}://{self.host}"
+
+
 AVAIALBLE_DATASOURCES = Union[
     NotionDatasourceConfiguration,
     ConfluenceDatasourceConfiguration,
     PdfDatasourceConfiguration,
+    HackernewsDatasourceConfiguration,
 ]

--- a/src/embedding/datasources/hackernews/builders.py
+++ b/src/embedding/datasources/hackernews/builders.py
@@ -1,0 +1,87 @@
+from injector import inject
+
+from common.bootstrap.configuration.pipeline.embedding.datasources.datasources_configuration import (
+    HackernewsDatasourceConfiguration,
+)
+from common.bootstrap.configuration.pipeline.embedding.embedding_model.embedding_model_binding_keys import (
+    BoundEmbeddingModelMarkdownSplitter,
+)
+from embedding.datasources.core.cleaner import Cleaner
+from embedding.datasources.hackernews.cleaner import HackernewsCleaner
+from embedding.datasources.hackernews.manager import HackernewsDatasourceManager
+from embedding.datasources.hackernews.reader import HackernewsReader
+
+
+class HackernewsDatasourceManagerBuilder:
+    """Builder for creating Hacker News datasource manager instances.
+
+    Provides factory method to create configured HackernewsDatasourceManager
+    with required components for content processing.
+    """
+
+    @staticmethod
+    @inject
+    def build(
+        configuration: HackernewsDatasourceConfiguration,
+        reader: HackernewsReader,
+        cleaner: Cleaner,
+        splitter: BoundEmbeddingModelMarkdownSplitter,
+    ) -> HackernewsDatasourceManager:
+        """Creates a configured Hacker News datasource manager.
+
+        Args:
+            configuration: Hacker News access and processing settings
+            reader: Component for reading Hacker News content
+            cleaner: Component for cleaning raw content
+            splitter: Component for splitting content into chunks
+
+        Returns:
+            HackernewsDatasourceManager: Configured manager instance
+        """
+        return HackernewsDatasourceManager(
+            configuration=configuration,
+            reader=reader,
+            cleaner=cleaner,
+            splitter=splitter,
+        )
+
+
+class HackernewsReaderBuilder:
+    """Builder for creating Hacker News reader instances.
+
+    Provides factory method to create configured HackernewsReader objects.
+    """
+
+    @staticmethod
+    @inject
+    def build(
+        configuration: HackernewsDatasourceConfiguration,
+    ) -> HackernewsReader:
+        """Creates a configured Hacker News reader.
+
+        Args:
+            configuration: Hacker News access settings
+
+        Returns:
+            HackernewsReader: Configured reader instance
+        """
+        return HackernewsReader(
+            configuration=configuration,
+        )
+
+
+class HackernewsCleanerBuilder:
+    """Builder for creating Hacker News content cleaner instances.
+
+    Provides factory method to create Cleaner objects for Hacker News content.
+    """
+
+    @staticmethod
+    @inject
+    def build() -> HackernewsCleaner:
+        """Creates a content cleaner for Hacker News.
+
+        Returns:
+            Cleaner: Configured cleaner instance
+        """
+        return HackernewsCleaner()

--- a/src/embedding/datasources/hackernews/cleaner.py
+++ b/src/embedding/datasources/hackernews/cleaner.py
@@ -1,0 +1,46 @@
+from typing import List
+
+from tqdm import tqdm
+
+from embedding.datasources.core.cleaner import BaseCleaner
+from embedding.datasources.hackernews.document import HackernewsDocument
+
+
+class HackernewsCleaner(BaseCleaner):
+    """
+    The `HackernewsCleaner` class is a concrete implementation of `BaseCleaner` for cleaning Hacker News documents.
+    """
+
+    def clean(
+        self, documents: List[HackernewsDocument]
+    ) -> List[HackernewsDocument]:
+        """
+        Clean the list of Hacker News documents. If the title or url is empty, it is not added to the cleaned documents.
+
+        :param documents: List of HackernewsDocument objects
+        :return: List of cleaned HackernewsDocument objects
+        """
+        cleaned_documents = []
+
+        for document in HackernewsCleaner._get_documents_with_tqdm(documents):
+            cleaned_documents.append(document)
+        return cleaned_documents
+
+    @staticmethod
+    def _get_documents_with_tqdm(documents: List[HackernewsDocument]):
+        """
+        Return the documents with tqdm progress bar if GlobalSettings.SHOW_PROGRESS is True, else return the documents as is.
+
+        :param documents: List of HackernewsDocument objects
+        """
+        return tqdm(documents, desc="[Hacker News] Cleaning documents")
+
+    @staticmethod
+    def _has_empty_fields(document: HackernewsDocument) -> bool:
+        """
+        Check if the document has empty title or url fields.
+
+        :param document: A HackernewsDocument object
+        :return: True if the title or url is empty, False otherwise
+        """
+        return not document.title or not document.url

--- a/src/embedding/datasources/hackernews/document.py
+++ b/src/embedding/datasources/hackernews/document.py
@@ -1,0 +1,50 @@
+from embedding.datasources.core.document import BaseDocument
+
+
+class HackernewsDocument(BaseDocument):
+    """
+    A document class for Hacker News stories.
+
+    Inherits from BaseDocument and provides a method to create a document
+    from a Hacker News story dictionary.
+
+    Attributes:
+        text: Markdown-formatted story content
+        metadata: Extracted story metadata including dates, IDs, and URLs
+        excluded_embed_metadata_keys: Metadata keys to exclude from embeddings
+        excluded_llm_metadata_keys: Metadata keys to exclude from LLM context
+    """
+
+    @classmethod
+    def from_story(cls, story: dict) -> "HackernewsDocument":
+        """
+        Create a HackernewsDocument from a Hacker News story dictionary.
+
+        Args:
+            story (dict): A dictionary containing the Hacker News story data.
+
+        Returns:
+            HackernewsDocument: An instance of HackernewsDocument with the title and URL set.
+        """
+        document = cls(
+            text=story.get("title", "") + " " + story.get("url", ""),
+            metadata=HackernewsDocument._get_metadata(story),
+        )
+        return document
+
+    @staticmethod
+    def _get_metadata(story: dict) -> dict:
+        """Extract and format page metadata.
+
+        Args:
+            story: Dictionary containing Hacker news story details
+
+        Returns:
+            dict: Structured metadata including type and IDs
+        """
+        return {
+            "type": story["type"],
+            "id": story["id"],
+            "title": story["title"],
+            "url": f"https://news.ycombinator.com/item?id={ story["id"]}",
+        }

--- a/src/embedding/datasources/hackernews/manager.py
+++ b/src/embedding/datasources/hackernews/manager.py
@@ -1,0 +1,12 @@
+from embedding.datasources.core.manager import DatasourceManager
+
+
+class HackernewsDatasourceManager(DatasourceManager):
+    """Manager for Hacker News content extraction and processing.
+
+    Handles document retrieval, cleaning, splitting, and embedding updates
+    for Hacker News stories. Implements the base DatasourceManager
+    interface for Hacker News-specific processing.
+    """
+
+    pass

--- a/src/embedding/datasources/hackernews/reader.py
+++ b/src/embedding/datasources/hackernews/reader.py
@@ -1,0 +1,76 @@
+import logging
+from typing import List
+
+import requests
+from tqdm import tqdm
+
+from common.bootstrap.configuration.pipeline.embedding.datasources.datasources_configuration import (
+    HackernewsDatasourceConfiguration,
+)
+from embedding.datasources.core.reader import BaseReader
+from embedding.datasources.hackernews.document import HackernewsDocument
+
+
+class HackernewsReader(BaseReader):
+    """Reader for extracting top stories from Hacker News.
+
+    Implements document extraction from Hacker News, handling pagination
+    and export limits. Supports both synchronous and asynchronous retrieval.
+
+    Attributes:
+        export_limit: Maximum number of documents to extract
+        base_url: Base URL for Hacker News API
+    """
+
+    def __init__(
+        self,
+        configuration: HackernewsDatasourceConfiguration,
+    ):
+        """Initialize the Hacker News reader.
+
+        Args:
+            configuration: Settings for Hacker News access and limits
+        """
+        super().__init__()
+        self.export_limit = configuration.export_limit
+        self.base_url = configuration.base_url
+
+    def get_all_documents(self) -> List[HackernewsDocument]:
+        """Synchronously fetch all top stories from Hacker News.
+
+        Returns:
+            List[HackernewsDocument]: List of extracted documents
+
+        Note:
+            Not implemented - use get_all_documents_async instead.
+        """
+        pass
+
+    async def get_all_documents_async(self) -> List[HackernewsDocument]:
+        """Asynchronously fetch all top stories from Hacker News.
+
+        Retrieves top stories from Hacker News, respecting export limit.
+
+        Returns:
+            List[HackernewsDocument]: List of extracted and processed documents
+        """
+        logging.info(
+            f"Fetching top stories from Hacker News with limit {self.export_limit}"
+        )
+        top_stories_url = f"{self.base_url}/v0/topstories.json"
+        response = requests.get(top_stories_url)
+        response.raise_for_status()
+        story_ids = response.json()
+
+        if self.export_limit is not None:
+            story_ids = story_ids[: self.export_limit]
+
+        documents = []
+        for story_id in tqdm(story_ids, desc="Fetching Hacker News stories"):
+            story_url = f"{self.base_url}/v0/item/{story_id}.json"
+            story_response = requests.get(story_url)
+            story_response.raise_for_status()
+            story = story_response.json()
+            documents.append(HackernewsDocument.from_story(story))
+
+        return documents

--- a/tests/embedding/datasources/hackernews/test_hackernews_reader.py
+++ b/tests/embedding/datasources/hackernews/test_hackernews_reader.py
@@ -1,0 +1,135 @@
+import sys
+from typing import List
+from unittest.mock import Mock, patch
+
+import pytest
+
+sys.path.append("./src")
+
+from common.bootstrap.configuration.pipeline.embedding.datasources.datasources_configuration import (
+    HackernewsDatasourceConfiguration,
+)
+from embedding.datasources.hackernews.document import HackernewsDocument
+from embedding.datasources.hackernews.reader import HackernewsReader
+
+
+class Fixtures:
+    def __init__(self):
+        self.export_limit: int = None
+        self.base_url: str = None
+        self.story_ids: List[int] = []
+        self.stories: dict = {}
+
+    def with_export_limit(self, export_limit: int) -> "Fixtures":
+        self.export_limit = export_limit
+        return self
+
+    def with_base_url(self) -> "Fixtures":
+        self.base_url = "https://hacker-news.firebaseio.com"
+        return self
+
+    def with_stories(self, number_of_stories: int) -> "Fixtures":
+        for i in range(number_of_stories):
+            story_id = i
+            self.story_ids.append(story_id)
+            self.stories[story_id] = {
+                "title": f"Title {i}",
+                "url": f"https://news.ycombinator.com/item?id={i}",
+            }
+        return self
+
+
+class Arrangements:
+    def __init__(self, fixtures: Fixtures):
+        self.fixtures = fixtures
+        self.configuration = Mock(spec=HackernewsDatasourceConfiguration)
+        self.configuration.export_limit = self.fixtures.export_limit
+        self.configuration.base_url = self.fixtures.base_url
+        self.service = HackernewsReader(configuration=self.configuration)
+
+    def on_requests_get(self) -> "Arrangements":
+        def requests_get_side_effect(url, *args, **kwargs):
+            if url.endswith("topstories.json"):
+                return Mock(
+                    status_code=200, json=lambda: self.fixtures.story_ids
+                )
+            else:
+                story_id = int(url.split("/")[-1].split(".")[0])
+                return Mock(
+                    status_code=200,
+                    json=lambda: self.fixtures.stories[story_id],
+                )
+
+        self.requests_get_patcher = patch(
+            "requests.get", side_effect=requests_get_side_effect
+        )
+        self.mock_requests_get = self.requests_get_patcher.start()
+        return self
+
+    def stop_patches(self):
+        self.requests_get_patcher.stop()
+
+
+class Assertions:
+    def __init__(self, arrangements: Arrangements):
+        self.fixtures = arrangements.fixtures
+        self.service = arrangements.service
+
+    def assert_documents(self, documents: List[HackernewsDocument]):
+        expected_story_ids = self.fixtures.story_ids
+        if self.fixtures.export_limit is not None:
+            expected_num_documents = min(
+                self.fixtures.export_limit, len(expected_story_ids)
+            )
+        else:
+            expected_num_documents = len(expected_story_ids)
+        assert len(documents) == expected_num_documents
+        for i, actual_document in enumerate(documents):
+            expected_story_id = expected_story_ids[i]
+            expected_story = self.fixtures.stories[expected_story_id]
+            assert (
+                actual_document.text
+                == expected_story["title"] + " " + expected_story["url"]
+            )
+
+
+class Manager:
+    def __init__(self, arrangements: Arrangements):
+        self.fixtures = arrangements.fixtures
+        self.arrangements = arrangements
+        self.assertions = Assertions(arrangements=arrangements)
+
+    def get_service(self) -> HackernewsReader:
+        return self.arrangements.service
+
+
+class TestHackernewsReader:
+    @pytest.mark.parametrize(
+        "export_limit,number_of_stories",
+        [
+            (5, 10),
+            (10, 15),
+            (None, 8),
+            (3, 5),
+            (20, 25),
+            (None, 0),
+            (5, 0),
+        ],
+    )
+    async def test(self, export_limit: int, number_of_stories: int) -> None:
+        # Arrange
+        manager = Manager(
+            Arrangements(
+                Fixtures()
+                .with_export_limit(export_limit)
+                .with_base_url()
+                .with_stories(number_of_stories)
+            ).on_requests_get()
+        )
+        service = manager.get_service()
+
+        # Act
+        documents = await service.get_all_documents_async()
+
+        # Assert
+        manager.assertions.assert_documents(documents)

--- a/tests/embedding/datasources/hackernews/test_hackernews_reader.py
+++ b/tests/embedding/datasources/hackernews/test_hackernews_reader.py
@@ -35,6 +35,8 @@ class Fixtures:
             self.stories[story_id] = {
                 "title": f"Title {i}",
                 "url": f"https://news.ycombinator.com/item?id={i}",
+                "type": "story",  # Add this line
+                "id": story_id,  # Add this line
             }
         return self
 
@@ -103,6 +105,7 @@ class Manager:
         return self.arrangements.service
 
 
+@pytest.mark.asyncio
 class TestHackernewsReader:
     @pytest.mark.parametrize(
         "export_limit,number_of_stories",


### PR DESCRIPTION
Add new data source - Hacker News Top stories. Fetching top stories using hacker-news.firebaseio.com [API](https://github.com/HackerNews/API) endpoint. Only using "Title" for embeddings and "URL" for reference.